### PR TITLE
Updated MFIS with March data

### DIFF
--- a/Prog/MFIS/MFIS_2017_03.sas
+++ b/Prog/MFIS/MFIS_2017_03.sas
@@ -1,0 +1,30 @@
+/**************************************************************************
+ Program:  MFIS_2017_03.sas
+ Library:  HUD
+ Project:  NeighborhoodInfo DC
+ Author:   
+ Created:  
+ Version:  SAS 9.2
+ Environment:  Local Windows session (desktop)
+ 
+ Description:  Compile HUD-insured multifamily mortgage data.
+ Creates files for DC, MD, VA, and WV.
+ 
+ Modifications:
+**************************************************************************/
+
+%include "L:\SAS\Inc\StdLocal.sas";
+
+** Define libraries **;
+%DCData_lib( HUD )
+%DCData_lib( RealProp )
+
+
+*--- EDIT PARAMETERS BELOW -----------------------------------------;
+
+%MFIS_read_update_file( 
+  filedate = '31mar2017'd,  /** Enter date of HUD database as SAS date value, ex: '25nov2014'd **/
+  revisions = %str(New file.)
+)
+  
+run;


### PR DESCRIPTION
@NeighborhoodInfoDC/review

Something else to check out - There should be new section 8 data as well, but the webpage that usually houses the database does not have the data: http://portal.hud.gov/hudportal/HUD?src=/program_offices/housing/mfh/exp/mfhdiscl. Wasn't able to find an alternate way to access the database.