### PR TITLE
Sec8 and MFIS update for February PresCat Update

### DIFF
--- a/Prog/MFIS/MFIS_2019_12.sas
+++ b/Prog/MFIS/MFIS_2019_12.sas
@@ -1,0 +1,30 @@
+/**************************************************************************
+ Program:  MFIS_2019_12.sas
+ Library:  HUD
+ Project:  Urban-Greater DC
+ Author:   W. Oliver
+ Created:  1/28/2020
+ Version:  SAS 9.4
+ Environment:  Local Windows session (desktop)
+ GitHub issue:  
+ 
+ Description:  Compile HUD-insured multifamily mortgage data.
+ Creates files for DC, MD, VA, and WV.
+ 
+**************************************************************************/
+
+%include "L:\SAS\Inc\StdLocal.sas";
+
+** Define libraries **;
+%DCData_lib( HUD )
+%DCData_lib( RealProp )
+
+
+*--- EDIT PARAMETERS BELOW -----------------------------------------;
+
+%MFIS_read_update_file( 
+  filedate = '31dec2019'd,  /** Enter date of HUD database as SAS date value, ex: '25nov2014'd **/
+  revisions = %str(New file.)
+)
+  
+run;

--- a/Prog/Sec8MF/Sec8MF_2019_12.sas
+++ b/Prog/Sec8MF/Sec8MF_2019_12.sas
@@ -1,0 +1,47 @@
+/**************************************************************************
+ Program:  Sec8MF_2019_12.sas
+ Library:  HUD
+ Project:  Urban-Greater DC
+ Author:   W. Oliver
+ Created:  1/28/2020
+ Version:  SAS 9.4
+ Environment:  Local Windows session (desktop)
+ GitHub issue:  
+ 
+ Description:  Compile Section 8 multifamily contract/project data.
+ Creates files for DC, MD, VA, and WV.
+ 
+**************************************************************************/
+
+%include "L:\SAS\Inc\StdLocal.sas";
+
+** Define libraries **;
+%DCData_lib( HUD )
+%DCData_lib( RealProp )
+
+
+*--- EDIT PARAMETERS BELOW -----------------------------------------;
+
+  ** Enter date of HUD database as SAS date value, ex: '25nov2014'd **;
+
+  %let s8filedate = '30dec2019'd;
+  
+  %let revisions = %str(New file.);
+
+*-------------------------------------------------------------------;
+
+
+*--- MAIN PROGRAM --------------------------------------------------;
+
+%sec8mf_readbasetbls( 
+  filedate=&s8filedate,
+  folder=&_dcdata_r_path\HUD
+)
+
+%Sec8MF_dmvw( 
+  filedate=&s8filedate,
+  revisions=&revisions 
+)
+
+run;
+


### PR DESCRIPTION
@mcohenui There are the same warnings from the last update regarding SOA category for MFIS and the management agent for Section 8. The SOA category error doesn't make sense because the code/description in question are listed in the Make_formats program already. Please review. 