### PR TITLE
Create Sec8 for PresCat January 2021 update

### DIFF
--- a/Prog/MFIS/MFIS_2021_01.sas
+++ b/Prog/MFIS/MFIS_2021_01.sas
@@ -1,0 +1,29 @@
+/**************************************************************************
+ Program:  MFIS_2021_01.sas
+ Library:  HUD
+ Project:  Urban-Greater DC
+ Author:   W.Oliver
+ Created:  1/7/2021
+ Version:  SAS 9.4
+ Environment:  Local Windows session (desktop)
+ GitHub issue:  
+ 
+ Description:  Compile HUD-insured multifamily mortgage data.
+ Creates files for DC, MD, VA, and WV.
+ 
+**************************************************************************/
+
+%include "\\sas1\DCdata\SAS\Inc\StdLocal.sas";
+** Define libraries **;
+%DCData_lib( HUD )
+%DCData_lib( RealProp )
+
+
+*--- EDIT PARAMETERS BELOW -----------------------------------------;
+
+%MFIS_read_update_file( 
+  filedate = '04jan2021'd,  /** Enter date of HUD database as SAS date value, ex: '25nov2014'd **/
+  revisions = %str(New file.)
+)
+  
+run;

--- a/Prog/REAC/REAC_2021_01.sas
+++ b/Prog/REAC/REAC_2021_01.sas
@@ -1,0 +1,31 @@
+/**************************************************************************
+ Program:  REAC_2021_01.sas
+ Library:  HUD
+ Project:  NeighborhoodInfo DC
+ Author:   K.Abazajian
+ Created:  9/22/16
+ Version:  SAS 9.4
+ Environment:  Local Windows session (desktop)
+ GitHub issue:  
+ 
+ Description:  Compile REAC scores data.
+ Creates files for DC, MD, VA, and WV.
+ 
+ Modifications:
+**************************************************************************/
+
+%include "\\sas1\DCdata\SAS\Inc\StdLocal.sas";
+
+** Define libraries **;
+%DCData_lib( HUD )
+%DCData_lib( RealProp )
+
+
+*--- EDIT PARAMETERS BELOW -----------------------------------------;
+
+%REAC_read_update_file( 
+  filedate = '04jan2021'd,  /** Enter date of HUD database as SAS date value, ex: '25nov2014'd **/
+  revisions = %str(New file.)
+)
+  
+run;

--- a/Prog/Sec8MF/Sec8MF_2021_01.sas
+++ b/Prog/Sec8MF/Sec8MF_2021_01.sas
@@ -1,0 +1,47 @@
+/**************************************************************************
+ Program:  Sec8MF_2020_01.sas
+ Library:  HUD
+ Project:  Urban-Greater DC
+ Author:   W. Oliver
+ Created:  1/5/2021
+ Version:  SAS 9.4
+ Environment:  Local Windows session (desktop)
+ GitHub issue:  
+ 
+ Description:  Compile Section 8 multifamily contract/project data.
+ Creates files for DC, MD, VA, and WV.
+ 
+**************************************************************************/
+
+%include "\\sas1\DCdata\SAS\Inc\StdLocal.sas";
+
+** Define libraries **;
+%DCData_lib( HUD )
+%DCData_lib( RealProp )
+
+
+*--- EDIT PARAMETERS BELOW -----------------------------------------;
+
+  ** Enter date of HUD database as SAS date value, ex: '25nov2014'd **;
+
+  %let s8filedate = '04jan2021'd;
+  
+  %let revisions = %str(New file.);
+
+*-------------------------------------------------------------------;
+
+
+*--- MAIN PROGRAM --------------------------------------------------;
+
+%sec8mf_readbasetbls( 
+  filedate=&s8filedate,
+  folder=&_dcdata_r_path\HUD
+)
+
+%Sec8MF_dmvw( 
+  filedate=&s8filedate,
+  revisions=&revisions 
+)
+
+run;
+


### PR DESCRIPTION
@mcohenui The warnings in the Sec 8 update are from a handful rows where the address was formatted incorrectly and spread across two additional columns. However, I don't believe that this affected the four states that we're using for the update. But let me know if I should make that change (and if it's something I need to do in SAS or in MS Access). Please review. 