### PR TITLE
HUD Updates for December PresCat

### DIFF
--- a/Prog/MFIS/MFIS_2021_11.sas
+++ b/Prog/MFIS/MFIS_2021_11.sas
@@ -1,0 +1,29 @@
+/**************************************************************************
+ Program:  MFIS_2021_11.sas
+ Library:  HUD
+ Project:  Urban-Greater DC
+ Author:   W. Oliver
+ Created:  12/10/2021
+ Version:  SAS 9.4
+ Environment:  Local Windows session (desktop)
+ GitHub issue:  
+ 
+ Description:  Compile HUD-insured multifamily mortgage data.
+ Creates files for DC, MD, VA, and WV.
+ 
+**************************************************************************/
+
+%include "\\sas1\DCdata\SAS\Inc\StdLocal.sas";
+** Define libraries **;
+%DCData_lib( HUD )
+%DCData_lib( RealProp )
+
+
+*--- EDIT PARAMETERS BELOW -----------------------------------------;
+
+%MFIS_read_update_file( 
+  filedate = '30nov2021'd,  /** Enter date of HUD database as SAS date value, ex: '25nov2014'd **/
+  revisions = %str(New file.)
+)
+  
+run;

--- a/Prog/REAC/REAC_2021_11.sas
+++ b/Prog/REAC/REAC_2021_11.sas
@@ -1,0 +1,31 @@
+/**************************************************************************
+ Program:  REAC_2021_11.sas
+ Library:  HUD
+ Project:  NeighborhoodInfo DC
+ Author:   W.Oliver
+ Created:  12/10/2021
+ Version:  SAS 9.4
+ Environment:  Local Windows session (desktop)
+ GitHub issue:  
+ 
+ Description:  Compile REAC scores data.
+ Creates files for DC, MD, VA, and WV.
+ 
+ Modifications:
+**************************************************************************/
+
+%include "\\sas1\DCdata\SAS\Inc\StdLocal.sas";
+
+** Define libraries **;
+%DCData_lib( HUD )
+%DCData_lib( RealProp )
+
+
+*--- EDIT PARAMETERS BELOW -----------------------------------------;
+
+%REAC_read_update_file( 
+  filedate = '02nov2021'd,  /** Enter date of HUD database as SAS date value, ex: '25nov2014'd **/
+  revisions = %str(New file.)
+)
+  
+run;

--- a/Prog/Sec8MF/Sec8MF_2021_12.sas
+++ b/Prog/Sec8MF/Sec8MF_2021_12.sas
@@ -1,0 +1,47 @@
+/**************************************************************************
+ Program:  Sec8MF_2021_12.sas
+ Library:  HUD
+ Project:  Urban-Greater DC
+ Author:   W.Oliver
+ Created:  12/10/2021
+ Version:  SAS 9.4
+ Environment:  Local Windows session (desktop)
+ GitHub issue:  
+ 
+ Description:  Compile Section 8 multifamily contract/project data.
+ Creates files for DC, MD, VA, and WV.
+ 
+**************************************************************************/
+
+%include "\\sas1\DCdata\SAS\Inc\StdLocal.sas";
+
+** Define libraries **;
+%DCData_lib( HUD )
+%DCData_lib( RealProp )
+
+
+*--- EDIT PARAMETERS BELOW -----------------------------------------;
+
+  ** Enter date of HUD database as SAS date value, ex: '25nov2014'd **;
+
+  %let s8filedate = '01dec2021'd;
+  
+  %let revisions = %str(New file.);
+
+*-------------------------------------------------------------------;
+
+
+*--- MAIN PROGRAM --------------------------------------------------;
+
+%sec8mf_readbasetbls( 
+  filedate=&s8filedate,
+  folder=&_dcdata_r_path\HUD
+)
+
+%Sec8MF_dmvw( 
+  filedate=&s8filedate,
+  revisions=&revisions 
+)
+
+run;
+


### PR DESCRIPTION
@ptatian Hi Peter. So the same warnings that are usually there for the Sec8MF and MFIS are still in the log, but I checked the outputs and it hasn't affected any of the data. I also checked the raw data and HUD doesn't appear to be collecting the owner name and other details anymore, save for a couple entries. Regarding the REAC update, there was an error for a file that I've never seen before. Here's the error below:
ERROR: Physical file does not exist, \\sas1\DCData\Libraries\HUD\raw\reac\11-02-2021\reacphyinspecscorreldates.csv

I ran an earlier version of the program and that error didn't come up and I didn't see this file mentioned in the log. 

Please review.